### PR TITLE
Char Selection Fix

### DIFF
--- a/interface/windowconfig/charcreation.config.patch
+++ b/interface/windowconfig/charcreation.config.patch
@@ -1,1 +1,1 @@
-[ { "op" : "add", "path" : "/speciesOrdering/-", "value" : "Ketian" } ]
+[ { "op" : "add", "path" : "/speciesOrdering/-", "value" : "ketian" } ]


### PR DESCRIPTION
- Removes the capitalisation of the species name in the char selection interface patch to fix it not appearing